### PR TITLE
修复点击第一个选择题前面元素时报Cannot read properties of null (reading 'click')

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,8 +27,8 @@ async function perform() {
     nodes = dom.querySelectorAll('#subject_box dl')
   }
 
-  for (let node of nodes) {
-    node.querySelector('dd a').click()
+ for (var i = 1; i < nodes.length; ++i) {
+    nodes[i].querySelector('dd a').click()
   }
   dom.getElementById('next_button').click()
   await sleep()


### PR DESCRIPTION
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'click')
    at HTMLIFrameElement.perform (main.js:31:31)